### PR TITLE
fix nonce length for paseto-v2

### DIFF
--- a/paseto-v2/src/core/local.rs
+++ b/paseto-v2/src/core/local.rs
@@ -46,7 +46,7 @@ impl paseto_core::version::SealingVersion<Local> for V2 {
     }
 
     fn nonce() -> Result<Vec<u8>, PasetoError> {
-        let mut nonce = [0; 32];
+        let mut nonce = [0; 24];
         getrandom::fill(&mut nonce).map_err(|_| PasetoError::CryptoError)?;
 
         let mut payload = Vec::with_capacity(64);


### PR DESCRIPTION
fixes #3 

see also https://github.com/paseto-standard/paseto-spec/blob/master/docs/01-Protocol-Versions/Version2.md

the nonce generated in the `fn nonce()` is the value `b` in the spec which should be 24 bytes, but is 32 bytes in the implementation. the result of `nonce()` is then concatenated with the payload and sent on to `dangerous_seal_with_nonce` which only extracts the first 24 bytes as the nonce - so 8 extra random bytes are effectively prepended to the payload. this causes a deserialization error after decryption.

setting the nonce size to 24 bytes (as prescribed by the spec) fixes the error; I didn't do any other checks though and don't have enough knowledge of paseto-rs otherwise to judge whether that is the right call here. potentially there should be associated constants for e.g. nonce and tag length so that there's fewer magics in the code?