### PR TITLE
type nonce and tag sizes on the version trait

### DIFF
--- a/paseto-core/src/tokens.rs
+++ b/paseto-core/src/tokens.rs
@@ -149,7 +149,7 @@ where
         self,
         key: &Key<V, P::SealingKey>,
         aad: &[u8],
-        nonce: Vec<u8>,
+        nonce: V::Nonce,
     ) -> Result<SealedToken<V, P, M, F>, PasetoError> {
         let mut footer = Vec::new();
         self.footer
@@ -157,7 +157,12 @@ where
             .map_err(PasetoError::PayloadError)?;
         let footer = footer.into_boxed_slice();
 
-        let mut payload = nonce;
+        // Pre-size with a 128-byte heuristic for typical JSON claims so the nonce
+        // write, claims encode, and trailing tag append all fit without realloc.
+        let nonce_len = core::mem::size_of::<V::Nonce>();
+        let tag_len = core::mem::size_of::<V::Tag>();
+        let mut payload = Vec::with_capacity(nonce_len + 128 + tag_len);
+        payload.extend_from_slice(nonce.as_ref());
         self.claims
             .encode(&mut payload)
             .map_err(PasetoError::PayloadError)?;

--- a/paseto-core/src/version.rs
+++ b/paseto-core/src/version.rs
@@ -18,7 +18,16 @@ type SealingKeyInner<V, P> = KeyInner<V, <P as Purpose>::SealingKey>;
 
 /// This PASETO implementation can decrypt/verify tokens.
 pub trait UnsealingVersion<P: Purpose>: HasKey<P> {
+    /// Per-message random input.
+    type Nonce: AsRef<[u8]>;
+
+    /// Authenticator appended to the payload: MAC tag for [`Local`] or signature for [`Public`].
+    type Tag: AsRef<[u8]>;
+
     /// Do not call this method directly. Use [`SealedToken::unseal`](crate::tokens::SealedToken::unseal) instead.
+    ///
+    /// `payload` arrives as `nonce || sealed(plaintext) || tag`. The implementer unseals in place
+    /// and returns the plaintext.
     fn unseal<'a>(
         key: &KeyInner<Self, P>,
         encoding: &'static str,
@@ -37,9 +46,12 @@ pub trait SealingVersion<P: Purpose>: UnsealingVersion<P> + HasKey<P::SealingKey
     fn random() -> Result<SealingKeyInner<Self, P>, PasetoError>;
 
     /// Do not call this method directly.
-    fn nonce() -> Result<Vec<u8>, PasetoError>;
+    fn nonce() -> Result<Self::Nonce, PasetoError>;
 
     /// Do not call this method directly. Use [`UnsealedToken::seal`](crate::tokens::UnsealedToken::seal) instead.
+    ///
+    /// `payload` arrives as `nonce || plaintext`. The implementer seals in place
+    /// and appends the [`tag`](Self::Tag).
     fn dangerous_seal_with_nonce(
         key: &SealingKeyInner<Self, P>,
         encoding: &'static str,

--- a/paseto-test/tests/paseto.rs
+++ b/paseto-test/tests/paseto.rs
@@ -1,7 +1,7 @@
 use libtest_mimic::{Arguments, Failed, Trial};
 use paseto_core::key::HasKey;
 use paseto_core::validation::NoValidation;
-use paseto_core::version::{Local, Public, SealingVersion, Secret};
+use paseto_core::version::{Local, Public, SealingVersion, Secret, UnsealingVersion};
 use paseto_core::{
     EncryptedToken, LocalKey, PublicKey, SecretKey, SignedToken, UnencryptedToken, UnsignedToken,
 };
@@ -43,6 +43,7 @@ where
     V: HasKey<Local, Key: Send>,
     V: HasKey<Public, Key: Send>,
     V: HasKey<Secret, Key: Send>,
+    <V as UnsealingVersion<Local>>::Nonce: for<'a> TryFrom<&'a [u8]>,
 {
     fn add_tests(name: &str, tests: &mut Vec<Trial>) {
         let test_file: TestFile<Self> = read_test(&format!("{}.json", V::HEADER));
@@ -102,6 +103,10 @@ where
                 let token = UnencryptedToken::<V, _>::new(decrypted_token.claims)
                     .with_footer(decrypted_token.footer);
 
+                let nonce: <V as UnsealingVersion<Local>>::Nonce = nonce
+                    .as_slice()
+                    .try_into()
+                    .map_err(|_| "nonce length does not match this version")?;
                 let token = token
                     .dangerous_seal_with_nonce(&key, implicit_assertion.as_bytes(), nonce)
                     .unwrap();

--- a/paseto-v1/src/core/local.rs
+++ b/paseto-v1/src/core/local.rs
@@ -66,13 +66,10 @@ impl paseto_core::version::SealingVersion<Local> for V1 {
         Ok(LocalKey(bytes))
     }
 
-    fn nonce() -> Result<Vec<u8>, PasetoError> {
+    fn nonce() -> Result<[u8; 32], PasetoError> {
         let mut nonce = [0; 32];
         getrandom::fill(&mut nonce).map_err(|_| PasetoError::CryptoError)?;
-
-        let mut payload = Vec::with_capacity(80);
-        payload.extend_from_slice(&nonce);
-        Ok(payload)
+        Ok(nonce)
     }
 
     fn dangerous_seal_with_nonce(
@@ -108,6 +105,9 @@ impl paseto_core::version::SealingVersion<Local> for V1 {
 
 #[cfg(feature = "decrypting")]
 impl paseto_core::version::UnsealingVersion<Local> for V1 {
+    type Nonce = [u8; 32];
+    type Tag = [u8; 48];
+
     fn unseal<'a>(
         key: &LocalKey,
         encoding: &'static str,

--- a/paseto-v1/src/core/public.rs
+++ b/paseto-v1/src/core/public.rs
@@ -97,8 +97,8 @@ impl paseto_core::version::SealingVersion<Public> for V1 {
         SecretKey::random()
     }
 
-    fn nonce() -> Result<Vec<u8>, PasetoError> {
-        Ok(Vec::with_capacity(96))
+    fn nonce() -> Result<[u8; 0], PasetoError> {
+        Ok([])
     }
 
     fn dangerous_seal_with_nonce(
@@ -133,6 +133,9 @@ impl paseto_core::version::SealingVersion<Public> for V1 {
 }
 
 impl paseto_core::version::UnsealingVersion<Public> for V1 {
+    type Nonce = [u8; 0];
+    type Tag = [u8; 256];
+
     fn unseal<'a>(
         key: &PublicKey,
         encoding: &'static str,

--- a/paseto-v2/src/core/local.rs
+++ b/paseto-v2/src/core/local.rs
@@ -45,13 +45,10 @@ impl paseto_core::version::SealingVersion<Local> for V2 {
         Ok(LocalKey(bytes))
     }
 
-    fn nonce() -> Result<Vec<u8>, PasetoError> {
+    fn nonce() -> Result<[u8; 24], PasetoError> {
         let mut nonce = [0; 24];
         getrandom::fill(&mut nonce).map_err(|_| PasetoError::CryptoError)?;
-
-        let mut payload = Vec::with_capacity(64);
-        payload.extend_from_slice(&nonce);
-        Ok(payload)
+        Ok(nonce)
     }
 
     fn dangerous_seal_with_nonce(
@@ -93,6 +90,9 @@ impl paseto_core::version::SealingVersion<Local> for V2 {
 
 #[cfg(feature = "decrypting")]
 impl paseto_core::version::UnsealingVersion<Local> for V2 {
+    type Nonce = [u8; 24];
+    type Tag = [u8; 16];
+
     fn unseal<'a>(
         key: &LocalKey,
         encoding: &'static str,

--- a/paseto-v2/src/core/public.rs
+++ b/paseto-v2/src/core/public.rs
@@ -83,8 +83,8 @@ impl paseto_core::version::SealingVersion<Public> for V2 {
         Ok(SecretKey(secret_key, esk))
     }
 
-    fn nonce() -> Result<Vec<u8>, PasetoError> {
-        Ok(Vec::with_capacity(32))
+    fn nonce() -> Result<[u8; 0], PasetoError> {
+        Ok([])
     }
 
     fn dangerous_seal_with_nonce(
@@ -106,6 +106,9 @@ impl paseto_core::version::SealingVersion<Public> for V2 {
 
 #[cfg(feature = "verifying")]
 impl paseto_core::version::UnsealingVersion<Public> for V2 {
+    type Nonce = [u8; 0];
+    type Tag = [u8; 64];
+
     fn unseal<'a>(
         key: &PublicKey,
         encoding: &'static str,

--- a/paseto-v3-aws-lc/src/core/local.rs
+++ b/paseto-v3-aws-lc/src/core/local.rs
@@ -64,15 +64,12 @@ impl paseto_core::version::SealingVersion<Local> for V3 {
         Ok(LocalKey(bytes))
     }
 
-    fn nonce() -> Result<Vec<u8>, PasetoError> {
+    fn nonce() -> Result<[u8; 32], PasetoError> {
         let mut nonce = [0; 32];
         SystemRandom::new()
             .fill(&mut nonce)
             .map_err(|_| PasetoError::CryptoError)?;
-
-        let mut payload = Vec::with_capacity(80);
-        payload.extend_from_slice(&nonce);
-        Ok(payload)
+        Ok(nonce)
     }
 
     fn dangerous_seal_with_nonce(
@@ -95,6 +92,9 @@ impl paseto_core::version::SealingVersion<Local> for V3 {
 }
 
 impl paseto_core::version::UnsealingVersion<Local> for V3 {
+    type Nonce = [u8; 32];
+    type Tag = [u8; 48];
+
     fn unseal<'a>(
         key: &LocalKey,
         encoding: &'static str,

--- a/paseto-v3-aws-lc/src/core/public.rs
+++ b/paseto-v3-aws-lc/src/core/public.rs
@@ -58,8 +58,8 @@ impl paseto_core::version::SealingVersion<Public> for V3 {
         SecretKey::random()
     }
 
-    fn nonce() -> Result<Vec<u8>, PasetoError> {
-        Ok(Vec::with_capacity(96))
+    fn nonce() -> Result<[u8; 0], PasetoError> {
+        Ok([])
     }
 
     fn dangerous_seal_with_nonce(
@@ -78,6 +78,9 @@ impl paseto_core::version::SealingVersion<Public> for V3 {
 }
 
 impl paseto_core::version::UnsealingVersion<Public> for V3 {
+    type Nonce = [u8; 0];
+    type Tag = [u8; 96];
+
     fn unseal<'a>(
         key: &PublicKey,
         encoding: &'static str,

--- a/paseto-v3/src/core/local.rs
+++ b/paseto-v3/src/core/local.rs
@@ -64,13 +64,10 @@ impl paseto_core::version::SealingVersion<Local> for V3 {
         Ok(LocalKey(bytes))
     }
 
-    fn nonce() -> Result<Vec<u8>, PasetoError> {
+    fn nonce() -> Result<[u8; 32], PasetoError> {
         let mut nonce = [0; 32];
         getrandom::fill(&mut nonce).map_err(|_| PasetoError::CryptoError)?;
-
-        let mut payload = Vec::with_capacity(80);
-        payload.extend_from_slice(&nonce);
-        Ok(payload)
+        Ok(nonce)
     }
 
     fn dangerous_seal_with_nonce(
@@ -95,6 +92,9 @@ impl paseto_core::version::SealingVersion<Local> for V3 {
 
 #[cfg(feature = "decrypting")]
 impl paseto_core::version::UnsealingVersion<Local> for V3 {
+    type Nonce = [u8; 32];
+    type Tag = [u8; 48];
+
     fn unseal<'a>(
         key: &LocalKey,
         encoding: &'static str,

--- a/paseto-v3/src/core/public.rs
+++ b/paseto-v3/src/core/public.rs
@@ -68,8 +68,8 @@ impl paseto_core::version::SealingVersion<Public> for V3 {
         SecretKey::random()
     }
 
-    fn nonce() -> Result<Vec<u8>, PasetoError> {
-        Ok(Vec::with_capacity(96))
+    fn nonce() -> Result<[u8; 0], PasetoError> {
+        Ok([])
     }
 
     fn dangerous_seal_with_nonce(
@@ -93,6 +93,9 @@ impl paseto_core::version::SealingVersion<Public> for V3 {
 }
 
 impl paseto_core::version::UnsealingVersion<Public> for V3 {
+    type Nonce = [u8; 0];
+    type Tag = [u8; 96];
+
     fn unseal<'a>(
         key: &PublicKey,
         encoding: &'static str,

--- a/paseto-v4-sodium/src/core/local.rs
+++ b/paseto-v4-sodium/src/core/local.rs
@@ -66,8 +66,10 @@ impl paseto_core::version::SealingVersion<Local> for V4 {
         Ok(LocalKey(bytes))
     }
 
-    fn nonce() -> Result<Vec<u8>, PasetoError> {
-        Ok(random::bytes(32))
+    fn nonce() -> Result<[u8; 32], PasetoError> {
+        let mut nonce = [0; 32];
+        random::fill_bytes(&mut nonce);
+        Ok(nonce)
     }
 
     fn dangerous_seal_with_nonce(
@@ -96,6 +98,9 @@ impl paseto_core::version::SealingVersion<Local> for V4 {
 }
 
 impl paseto_core::version::UnsealingVersion<Local> for V4 {
+    type Nonce = [u8; 32];
+    type Tag = [u8; 32];
+
     fn unseal<'a>(
         key: &LocalKey,
         encoding: &'static str,

--- a/paseto-v4-sodium/src/core/public.rs
+++ b/paseto-v4-sodium/src/core/public.rs
@@ -58,8 +58,8 @@ impl paseto_core::version::SealingVersion<Public> for V4 {
         }
     }
 
-    fn nonce() -> Result<Vec<u8>, PasetoError> {
-        Ok(Vec::with_capacity(32))
+    fn nonce() -> Result<[u8; 0], PasetoError> {
+        Ok([])
     }
 
     fn dangerous_seal_with_nonce(
@@ -78,6 +78,9 @@ impl paseto_core::version::SealingVersion<Public> for V4 {
 }
 
 impl paseto_core::version::UnsealingVersion<Public> for V4 {
+    type Nonce = [u8; 0];
+    type Tag = [u8; 64];
+
     fn unseal<'a>(
         key: &PublicKey,
         encoding: &'static str,

--- a/paseto-v4/src/core/local.rs
+++ b/paseto-v4/src/core/local.rs
@@ -65,13 +65,10 @@ impl paseto_core::version::SealingVersion<Local> for V4 {
         Ok(LocalKey(bytes))
     }
 
-    fn nonce() -> Result<Vec<u8>, PasetoError> {
+    fn nonce() -> Result<[u8; 32], PasetoError> {
         let mut nonce = [0; 32];
         getrandom::fill(&mut nonce).map_err(|_| PasetoError::CryptoError)?;
-
-        let mut payload = Vec::with_capacity(64);
-        payload.extend_from_slice(&nonce);
-        Ok(payload)
+        Ok(nonce)
     }
 
     fn dangerous_seal_with_nonce(
@@ -83,8 +80,8 @@ impl paseto_core::version::SealingVersion<Local> for V4 {
     ) -> Result<Vec<u8>, PasetoError> {
         let (nonce, ciphertext) = payload.split_at_mut(32);
         let nonce: &[u8] = nonce;
-
         let nonce: &[u8; 32] = nonce.try_into().unwrap();
+
         let (mut cipher, mut mac) = key.keys(nonce);
         cipher.apply_keystream(ciphertext);
         preauth_local(&mut mac, encoding, nonce, ciphertext, footer, aad);
@@ -96,6 +93,9 @@ impl paseto_core::version::SealingVersion<Local> for V4 {
 
 #[cfg(feature = "decrypting")]
 impl paseto_core::version::UnsealingVersion<Local> for V4 {
+    type Nonce = [u8; 32];
+    type Tag = [u8; 32];
+
     fn unseal<'a>(
         key: &LocalKey,
         encoding: &'static str,

--- a/paseto-v4/src/core/public.rs
+++ b/paseto-v4/src/core/public.rs
@@ -83,8 +83,8 @@ impl paseto_core::version::SealingVersion<Public> for V4 {
         Ok(SecretKey(secret_key, esk))
     }
 
-    fn nonce() -> Result<Vec<u8>, PasetoError> {
-        Ok(Vec::with_capacity(32))
+    fn nonce() -> Result<[u8; 0], PasetoError> {
+        Ok([])
     }
 
     fn dangerous_seal_with_nonce(
@@ -102,6 +102,9 @@ impl paseto_core::version::SealingVersion<Public> for V4 {
 
 #[cfg(feature = "verifying")]
 impl paseto_core::version::UnsealingVersion<Public> for V4 {
+    type Nonce = [u8; 0];
+    type Tag = [u8; 64];
+
     fn unseal<'a>(
         key: &PublicKey,
         encoding: &'static str,


### PR DESCRIPTION
enforce nonce sizes for better type safety. I've again verified this catches the bug in #3.