### PR TITLE
implement Zeroize trait from zeroize crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,63 @@
+name: CI
+
+on:
+  workflow_dispatch:
+  push:
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  format:
+    name: rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - name: Check formatting
+        run: cargo fmt --check --all
+
+  lint:
+    name: clippy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - name: Run clippy
+        run: cargo clippy
+
+  test:
+    runs-on: ubuntu-latest
+    name: tests
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      - run: cargo test
+      - run: cargo test --no-default-features
+      - run: cargo test -p paseto-v1 --all-features
+      - run: cargo test -p paseto-v2 --all-features
+      - run: cargo test -p paseto-v3 --all-features
+      - run: cargo test -p paseto-v3-aws-lc -F zeroize non-fips # requires cmake, go
+      - run: cargo test -p paseto-v3-aws-lc -F zeroize fips # requires cmake, go
+      - run: cargo test -p paseto-v4 --all-features
+      - run: cargo test -p paseto-v5 --all-features
+      - run: cargo test -p paseto-v6 --all-features
+
+  bench:
+    runs-on: ubuntu-latest
+    name: benchmarks
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      - run: cargo bench

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1649,6 +1649,7 @@ name = "paseto-core"
 version = "0.1.0-rc.9"
 dependencies = [
  "serde_core",
+ "zeroize",
 ]
 
 [[package]]
@@ -1701,6 +1702,7 @@ dependencies = [
  "rsa",
  "sha2 0.11.0",
  "zerocopy",
+ "zeroize",
 ]
 
 [[package]]
@@ -1722,6 +1724,7 @@ dependencies = [
  "paseto-json",
  "sha2 0.11.0",
  "zerocopy",
+ "zeroize",
 ]
 
 [[package]]
@@ -1742,6 +1745,7 @@ dependencies = [
  "pbkdf2",
  "sha2 0.11.0",
  "zerocopy",
+ "zeroize",
 ]
 
 [[package]]
@@ -1752,6 +1756,7 @@ dependencies = [
  "paseto-core",
  "paseto-json",
  "zerocopy",
+ "zeroize",
 ]
 
 [[package]]
@@ -1772,6 +1777,7 @@ dependencies = [
  "paseto-json",
  "sha2 0.11.0",
  "zerocopy",
+ "zeroize",
 ]
 
 [[package]]
@@ -1783,6 +1789,7 @@ dependencies = [
  "paseto-core",
  "paseto-json",
  "zerocopy",
+ "zeroize",
 ]
 
 [[package]]
@@ -1804,6 +1811,7 @@ dependencies = [
  "pbkdf2",
  "sha2 0.11.0",
  "zerocopy",
+ "zeroize",
 ]
 
 [[package]]
@@ -1823,6 +1831,7 @@ dependencies = [
  "slh-dsa",
  "x-wing",
  "zerocopy",
+ "zeroize",
 ]
 
 [[package]]
@@ -3226,18 +3235,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # paseto-rs
 
+[![crates.io version](https://img.shields.io/crates/v/paseto-core)](https://crates.io/crates/paseto-core)
+[![docs.rs](https://img.shields.io/docsrs/paseto-core)](https://docs.rs/paseto-core)
+
 ## Crates
 
 * `paseto-core`, contains core types and traits common to all versions of PASETO

--- a/paseto-core/Cargo.toml
+++ b/paseto-core/Cargo.toml
@@ -18,6 +18,8 @@ categories = [
 [features]
 default = []
 serde = ["dep:serde_core"]
+zeroize = ["dep:zeroize"]
 
 [dependencies]
 serde_core = { version = "1", default-features = false, optional = true }
+zeroize = { version = "1", features = ["derive"], optional = true }

--- a/paseto-core/src/key.rs
+++ b/paseto-core/src/key.rs
@@ -127,3 +127,19 @@ impl KeyType for PkePublic {
     const HEADER: &'static str = ".public.";
     const ID_HEADER: &'static str = ".pid.";
 }
+
+#[cfg(feature = "zeroize")]
+impl<V: HasKey<K>, K: KeyType> zeroize::Zeroize for Key<V, K>
+where
+    KeyInner<V, K>: zeroize::Zeroize,
+{
+    fn zeroize(&mut self) {
+        zeroize::Zeroize::zeroize(&mut self.0);
+    }
+}
+
+#[cfg(feature = "zeroize")]
+impl<V: HasKey<K>, K: KeyType> zeroize::ZeroizeOnDrop for Key<V, K> where
+    KeyInner<V, K>: zeroize::ZeroizeOnDrop
+{
+}

--- a/paseto-core/src/paserk/pke.rs
+++ b/paseto-core/src/paserk/pke.rs
@@ -49,6 +49,7 @@ impl<V: PkeUnsealingVersion> Key<V, PkeSecret> {
 ///
 /// * Encrypted using [`LocalKey::seal`]
 /// * Decrypted using [`SealedKey::unseal`]
+#[cfg_attr(feature = "zeroize", derive(zeroize::Zeroize, zeroize::ZeroizeOnDrop))]
 pub struct SealedKey<V: Version> {
     key_data: Box<[u8]>,
     _version: PhantomData<V>,
@@ -100,7 +101,13 @@ impl<V: PkeSealingVersion> LocalKey<V> {
 impl<V: PkeUnsealingVersion> SealedKey<V> {
     /// Decrypt the sealed key.
     pub fn unseal(self, with: &Key<V, PkeSecret>) -> Result<LocalKey<V>, PasetoError> {
-        V::unseal_key(&with.0, self.key_data).map(Key)
+        #[cfg(not(feature = "zeroize"))]
+        let key_data = self.key_data;
+
+        #[cfg(feature = "zeroize")]
+        let key_data = self.key_data.clone();
+
+        V::unseal_key(&with.0, key_data).map(Key)
     }
 }
 

--- a/paseto-core/src/paserk/pke.rs
+++ b/paseto-core/src/paserk/pke.rs
@@ -49,7 +49,6 @@ impl<V: PkeUnsealingVersion> Key<V, PkeSecret> {
 ///
 /// * Encrypted using [`LocalKey::seal`]
 /// * Decrypted using [`SealedKey::unseal`]
-#[cfg_attr(feature = "zeroize", derive(zeroize::Zeroize, zeroize::ZeroizeOnDrop))]
 pub struct SealedKey<V: Version> {
     key_data: Box<[u8]>,
     _version: PhantomData<V>,
@@ -101,13 +100,7 @@ impl<V: PkeSealingVersion> LocalKey<V> {
 impl<V: PkeUnsealingVersion> SealedKey<V> {
     /// Decrypt the sealed key.
     pub fn unseal(self, with: &Key<V, PkeSecret>) -> Result<LocalKey<V>, PasetoError> {
-        #[cfg(not(feature = "zeroize"))]
-        let key_data = self.key_data;
-
-        #[cfg(feature = "zeroize")]
-        let key_data = self.key_data.clone();
-
-        V::unseal_key(&with.0, key_data).map(Key)
+        V::unseal_key(&with.0, self.key_data).map(Key)
     }
 }
 

--- a/paseto-core/src/paserk/plaintext.rs
+++ b/paseto-core/src/paserk/plaintext.rs
@@ -9,6 +9,7 @@ use crate::version::Version;
 /// A plaintext encoding of a key.
 ///
 /// Be advised that this encoding has no extra security, so it is not safe to transport as is.
+#[cfg_attr(feature = "zeroize", derive(zeroize::Zeroize, zeroize::ZeroizeOnDrop))]
 pub struct KeyText<V: Version, K: KeyType> {
     data: Box<[u8]>,
     _key: PhantomData<(V, K)>,

--- a/paseto-v1/Cargo.toml
+++ b/paseto-v1/Cargo.toml
@@ -29,9 +29,12 @@ id = []
 pbkw = ["encrypting", "dep:pbkdf2", "dep:getrandom"]
 pie-wrap = ["encrypting", "dep:getrandom"]
 pke = ["encrypting", "signing", "dep:getrandom", "rsa?/hazmat"]
+zeroize = ["paseto-core/zeroize", "dep:zeroize"]
 
 [dependencies]
 paseto-core.workspace = true
+
+zeroize = { version = "1", features = ["derive"], optional = true }
 
 hybrid-array = "0.4"
 cipher = { version = "0.5", default-features = false }

--- a/paseto-v1/src/core/mod.rs
+++ b/paseto-v1/src/core/mod.rs
@@ -22,6 +22,7 @@ pub struct PublicKey(rsa::pss::VerifyingKey<sha2::Sha384>);
 
 #[cfg(feature = "decrypting")]
 #[derive(Clone)]
+#[cfg_attr(feature = "zeroize", derive(zeroize::Zeroize, zeroize::ZeroizeOnDrop))]
 pub struct LocalKey([u8; 32]);
 
 impl version::Version for V1 {

--- a/paseto-v2/Cargo.toml
+++ b/paseto-v2/Cargo.toml
@@ -29,9 +29,12 @@ id = ["dep:blake2"]
 pbkw = ["encrypting", "dep:argon2", "dep:getrandom"]
 pie-wrap = ["encrypting", "dep:getrandom"]
 pke = ["encrypting", "signing", "dep:getrandom"]
+zeroize = ["paseto-core/zeroize", "dep:zeroize"]
 
 [dependencies]
 paseto-core.workspace = true
+
+zeroize = { version = "1", features = ["derive"], optional = true }
 
 hybrid-array = "0.4"
 cipher = "0.5"

--- a/paseto-v2/src/core/mod.rs
+++ b/paseto-v2/src/core/mod.rs
@@ -15,6 +15,7 @@ pub struct V2;
 
 #[cfg(feature = "decrypting")]
 #[derive(Clone)]
+#[cfg_attr(feature = "zeroize", derive(zeroize::Zeroize, zeroize::ZeroizeOnDrop))]
 pub struct LocalKey([u8; 32]);
 
 #[cfg(feature = "signing")]

--- a/paseto-v3-aws-lc/Cargo.toml
+++ b/paseto-v3-aws-lc/Cargo.toml
@@ -24,12 +24,16 @@ non-fips = ["aws-lc-rs/non-fips"]
 # require FIPS
 fips = ["aws-lc-rs/fips"]
 
+zeroize = ["paseto-core/zeroize", "dep:zeroize"]
+
 [dependencies]
 paseto-core.workspace = true
 
 zerocopy = { version = "0.8", features = ["derive"] }
 
 aws-lc-rs = "1.16"
+
+zeroize = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
 paseto-json.workspace = true

--- a/paseto-v3-aws-lc/src/core/mod.rs
+++ b/paseto-v3-aws-lc/src/core/mod.rs
@@ -12,11 +12,13 @@ use crate::lc::{SigningKey, VerifyingKey};
 
 pub struct V3;
 #[derive(Clone)]
+#[cfg_attr(feature = "zeroize", derive(zeroize::Zeroize, zeroize::ZeroizeOnDrop))]
 pub struct SecretKey(SigningKey);
 #[derive(Clone)]
 pub struct PublicKey(VerifyingKey);
 
 #[derive(Clone)]
+#[cfg_attr(feature = "zeroize", derive(zeroize::Zeroize, zeroize::ZeroizeOnDrop))]
 pub struct LocalKey([u8; 32]);
 
 impl paseto_core::version::Version for V3 {

--- a/paseto-v3-aws-lc/src/core/pke.rs
+++ b/paseto-v3-aws-lc/src/core/pke.rs
@@ -65,7 +65,10 @@ impl PkeSealingVersion for V3 {
     fn seal_key(sealing_key: &PublicKey, key: LocalKey) -> Result<Box<[u8]>, PasetoError> {
         let pk = sealing_key.0.compressed_pub_key();
 
+        #[cfg(not(feature = "zeroize"))]
         let esk = SecretKey::random()?.0;
+        #[cfg(feature = "zeroize")]
+        let esk = SecretKey::random()?.0.clone();
         let epk = esk.verifying_key().compressed_pub_key();
 
         let xk = esk.diffie_hellman(&sealing_key.0)?;

--- a/paseto-v3-aws-lc/src/core/pke.rs
+++ b/paseto-v3-aws-lc/src/core/pke.rs
@@ -65,13 +65,10 @@ impl PkeSealingVersion for V3 {
     fn seal_key(sealing_key: &PublicKey, key: LocalKey) -> Result<Box<[u8]>, PasetoError> {
         let pk = sealing_key.0.compressed_pub_key();
 
-        #[cfg(not(feature = "zeroize"))]
-        let esk = SecretKey::random()?.0;
-        #[cfg(feature = "zeroize")]
-        let esk = SecretKey::random()?.0.clone();
-        let epk = esk.verifying_key().compressed_pub_key();
+        let esk = SecretKey::random()?;
+        let epk = esk.0.verifying_key().compressed_pub_key();
 
-        let xk = esk.diffie_hellman(&sealing_key.0)?;
+        let xk = esk.0.diffie_hellman(&sealing_key.0)?;
 
         let (cipher, mac) = seal_keys(&xk, &epk, &pk)?;
 

--- a/paseto-v3-aws-lc/src/lc/mod.rs
+++ b/paseto-v3-aws-lc/src/lc/mod.rs
@@ -7,6 +7,7 @@ use aws_lc_rs::signature::{
 use paseto_core::PasetoError;
 
 #[derive(Clone)]
+#[cfg_attr(feature = "zeroize", derive(zeroize::Zeroize, zeroize::ZeroizeOnDrop))]
 pub struct SigningKey {
     scalar: [u8; 48],
     compressed_pubkey: [u8; 49],

--- a/paseto-v3/Cargo.toml
+++ b/paseto-v3/Cargo.toml
@@ -29,9 +29,12 @@ id = []
 pbkw = ["encrypting", "dep:pbkdf2", "dep:getrandom"]
 pie-wrap = ["encrypting", "dep:getrandom"]
 pke = ["encrypting", "signing", "dep:getrandom", "p384?/ecdh"]
+zeroize = ["paseto-core/zeroize", "dep:zeroize"]
 
 [dependencies]
 paseto-core.workspace = true
+
+zeroize = { version = "1", features = ["derive"], optional = true }
 
 hybrid-array = "0.4"
 cipher = { version = "0.5", default-features = false }

--- a/paseto-v3/src/core/mod.rs
+++ b/paseto-v3/src/core/mod.rs
@@ -22,6 +22,7 @@ pub struct PublicKey(p384::ecdsa::VerifyingKey);
 
 #[cfg(feature = "decrypting")]
 #[derive(Clone)]
+#[cfg_attr(feature = "zeroize", derive(zeroize::Zeroize, zeroize::ZeroizeOnDrop))]
 pub struct LocalKey([u8; 32]);
 
 impl version::Version for V3 {

--- a/paseto-v4-sodium/Cargo.toml
+++ b/paseto-v4-sodium/Cargo.toml
@@ -15,10 +15,15 @@ categories = [
   "web-programming",
 ]
 
+[features]
+default = []
+zeroize = ["paseto-core/zeroize", "dep:zeroize"]
+
 [dependencies]
 paseto-core.workspace = true
 libsodium-rs = "0.2"
 zerocopy = { version = "0.8", features = ["derive"] }
+zeroize = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
 paseto-json.workspace = true

--- a/paseto-v4-sodium/src/core/mod.rs
+++ b/paseto-v4-sodium/src/core/mod.rs
@@ -9,12 +9,14 @@ use libsodium_rs::{crypto_generichash, crypto_sign};
 pub struct V4;
 
 #[derive(Clone)]
+#[cfg_attr(feature = "zeroize", derive(zeroize::Zeroize, zeroize::ZeroizeOnDrop))]
 pub struct SecretKey(crypto_sign::SecretKey);
 
 #[derive(Clone)]
 pub struct PublicKey(crypto_sign::PublicKey);
 
 #[derive(Clone)]
+#[cfg_attr(feature = "zeroize", derive(zeroize::Zeroize, zeroize::ZeroizeOnDrop))]
 pub struct LocalKey([u8; 32]);
 
 impl paseto_core::version::Version for V4 {

--- a/paseto-v4/Cargo.toml
+++ b/paseto-v4/Cargo.toml
@@ -29,9 +29,12 @@ id = ["dep:blake2"]
 pbkw = ["encrypting", "dep:argon2", "dep:getrandom"]
 pie-wrap = ["encrypting", "dep:getrandom"]
 pke = ["encrypting", "signing", "dep:getrandom"]
+zeroize = ["paseto-core/zeroize", "dep:zeroize"]
 
 [dependencies]
 paseto-core.workspace = true
+
+zeroize = { version = "1", features = ["derive"], optional = true }
 
 hybrid-array = "0.4"
 cipher = "0.5"

--- a/paseto-v4/src/core/mod.rs
+++ b/paseto-v4/src/core/mod.rs
@@ -15,6 +15,7 @@ pub struct V4;
 
 #[cfg(feature = "decrypting")]
 #[derive(Clone)]
+#[cfg_attr(feature = "zeroize", derive(zeroize::Zeroize, zeroize::ZeroizeOnDrop))]
 pub struct LocalKey([u8; 32]);
 
 #[cfg(feature = "signing")]

--- a/paseto-v5/Cargo.toml
+++ b/paseto-v5/Cargo.toml
@@ -22,9 +22,12 @@ id = []
 pbkw = ["encrypting", "dep:pbkdf2", "dep:getrandom"]
 pie-wrap = ["encrypting", "dep:getrandom"]
 pke = ["encrypting", "dep:ml-kem", "dep:getrandom"]
+zeroize = ["paseto-core/zeroize", "dep:zeroize"]
 
 [dependencies]
 paseto-core.workspace = true
+
+zeroize = { version = "1", features = ["derive"], optional = true }
 
 hybrid-array = "0.4"
 cipher = { version = "0.5", default-features = false }

--- a/paseto-v5/src/core/mod.rs
+++ b/paseto-v5/src/core/mod.rs
@@ -15,6 +15,7 @@ pub struct V5;
 
 #[cfg(feature = "decrypting")]
 #[derive(Clone)]
+#[cfg_attr(feature = "zeroize", derive(zeroize::Zeroize, zeroize::ZeroizeOnDrop))]
 pub struct LocalKey([u8; 32]);
 
 #[cfg(feature = "signing")]

--- a/paseto-v6/Cargo.toml
+++ b/paseto-v6/Cargo.toml
@@ -22,9 +22,12 @@ id = ["dep:blake2"]
 pbkw = ["encrypting", "dep:argon2", "dep:getrandom"]
 pie-wrap = ["encrypting", "dep:getrandom"]
 pke = ["encrypting", "dep:x-wing", "dep:getrandom"]
+zeroize = ["paseto-core/zeroize", "dep:zeroize"]
 
 [dependencies]
 paseto-core.workspace = true
+
+zeroize = { version = "1", features = ["derive"], optional = true }
 
 hybrid-array = "0.4"
 cipher = { version = "0.5", default-features = false }

--- a/paseto-v6/src/core/mod.rs
+++ b/paseto-v6/src/core/mod.rs
@@ -15,6 +15,7 @@ pub struct V6;
 
 #[cfg(feature = "decrypting")]
 #[derive(Clone)]
+#[cfg_attr(feature = "zeroize", derive(zeroize::Zeroize, zeroize::ZeroizeOnDrop))]
 pub struct LocalKey([u8; 32]);
 
 #[cfg(feature = "signing")]


### PR DESCRIPTION
Introduced as an optional feature "zeroize"

Note: the zeroize trait was implemented only on types which can be zeroized:
- LocalKey: holding raw bytes
- paseto-v3-aws-lc: SecretKey: zeroize was implemented on the underlying
  SigningKey struct as well

For other cases, the underlying types (coming from external crates)
cannot be zeroized, thus could not implement the trait.

So realistically, zeroize can be used only when using the feature
`decrypting`.



## Misc

It was also the opportunity to run tests in CI, and to add small badges to docs.rs and crates.io (I know I always look for them when landing on rust GitHub repos)